### PR TITLE
의존 오브젝트 추가

### DIFF
--- a/src/main/java/ginseng/study_springboot/HelloController.java
+++ b/src/main/java/ginseng/study_springboot/HelloController.java
@@ -1,9 +1,13 @@
 package ginseng.study_springboot;
 
+import java.util.Objects;
+
 public class HelloController {
 
     public String hello(String name) {
-        return "Hello " + name;
+        SimpleHelloService helloService = new SimpleHelloService();
+
+        return helloService.sayHello(Objects.requireNonNull(name));
     }
 
 

--- a/src/main/java/ginseng/study_springboot/SimpleHelloService.java
+++ b/src/main/java/ginseng/study_springboot/SimpleHelloService.java
@@ -1,0 +1,9 @@
+package ginseng.study_springboot;
+
+public class SimpleHelloService {
+
+    public String sayHello(String name) {
+        return "Hello " + name;
+    }
+
+}


### PR DESCRIPTION
서블릿에서 요청을 처리할 스프링 컨테이너를 만들었다.
스프링 컨테이너에서 등록해둔 HelloController를  서블릿에서 getBean으로 가져다 쓸 수 있게 되었다.
스프링컨테이너가 할 수 있는 일들을, 이후에 계속 적용하도록 구조를 짜놨다는게 중요하다.


스프링컨테이너는 어떤타입의 오브젝트를 만들 때 딱 한번만 만든다. 
앞에서 여러개의 서블릿이 HelloController를 사용하고 싶다고 SpringContainer에 요청해도, 
스프링컨테이너는 하나의 오브젝트를 재사용한다.

